### PR TITLE
Fix doc error: genotype_prompt will not recognize "exit" line

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -260,7 +260,7 @@ Option _-nomak_ turns off P filtering of SNPs (1000 Genome Project strict mask) 
 Genotype all called CNVs:
 
 ```
-> awk '{ print $2 } END { print "exit" }' calls.10000.tsv | cnvpytor -root file.pytor -genotype 10000 100000
+> awk '{ print $2 }' calls.10000.tsv | cnvpytor -root file.pytor -genotype 10000 100000
 ```
 
 ## Visualization


### PR DESCRIPTION
The documentation had said to include an "exit" line at the
end of list of regions to genotype, but the genotype_prompt
function's loop does not recognize this command as ending
the file, but tries to parse it as a region.

Getting rid of this results in the program ending after there
is no more input (which is idiomatic for most programs, anyway).

This addresses #16, which was closed but still had the wrong info
in the documentation.