### PR TITLE
accept main-assembly chromosome names in refseq format

### DIFF
--- a/cnvpytor/genome.py
+++ b/cnvpytor/genome.py
@@ -88,6 +88,16 @@ class Genome:
         cname = name.upper().replace("CHROMOSOME", "").replace("CHROM", "").replace("CHR", "")
         if cname == "MT":
             cname = "M"
+        if cname.startswith('NC_'):
+            chrom_num = int(float(cname[3:]))
+            if chrom_num <= 22:
+                cname = str(chrom_num)
+            elif chrom_num == 23:
+                cname = 'X'
+            elif chrom_num == 24:
+                cname = 'Y'
+            elif chrom_num == 12920:
+                cname = 'M'
         return cname
 
     @staticmethod


### PR DESCRIPTION
This (somewhat simplistically) allows use of human genome references where the chromosome names are given as refseq accessions (e.g., NC_000003.11 for chromosome 3 version 11), converting them to the "short form" used elsewhere internally.

Only the primary assembly chromosomes are handled (e.g. the autosomes, X, Y and MT sequence, but not alternate contigs), others would be passed through as-is.