### PR TITLE
fix(cli): allow version to be printed

### DIFF
--- a/cnvpytor/__main__.py
+++ b/cnvpytor/__main__.py
@@ -184,13 +184,13 @@ def main():
         Genome.download_resources()
         return 0
 
+    if args.version:
+        print('CNVpytor {}'.format(__version__))
+        return 0
+
     if not Genome.check_resources():
         logger.error("Some reference genome resource files are missing. "
                      "Run 'cnvpytor -download' as same user who has installed cnvpytor.")
-        return 0
-
-    if args.version:
-        print('CNVpytor {}'.format(__version__))
         return 0
 
     if args.reference_genomes_conf:


### PR DESCRIPTION
This PR allows the version to be to be printed by `cnvpytor --help` before checking for reference genome resource files.

Closes #282.
